### PR TITLE
Fix action display if multiple switch message set actions

### DIFF
--- a/casepropods/family_connect_subscription/karma/test-pod.coffee
+++ b/casepropods/family_connect_subscription/karma/test-pod.coffee
@@ -147,6 +147,31 @@ describe('directives:', () ->
       expect(item5.querySelector('.pod-item-value').textContent)
         .toMatch('False')
     )
+
+    it('should draw the pod actions even if the types aren\'t unique', ->
+      $rootScope.podData.actions = [{
+        type: 'switch',
+        name: 'test_set_1',
+        busyText: 'Foo',
+        isBusy: false,
+        payload: {bar: 'baz'}
+      }, {
+        type: 'switch',
+        name: 'test_set_2',
+        busyText: 'Quux',
+        isBusy: false,
+        payload: {corge: 'grault'}
+      }]
+
+      el = $compile('<subscription-pod/>')($rootScope)[0]
+      $rootScope.$digest()
+
+      action1 = el.querySelectorAll('.pod-action')[0]
+      action2 = el.querySelectorAll('.pod-action')[1]
+
+      expect(action1.textContent).toContain('test_set_1')
+      expect(action2.textContent).toContain('test_set_2')
+    )
     
 
     it('should draw whether it is loading', () ->

--- a/casepropods/family_connect_subscription/static/subscription_pod_template.html
+++ b/casepropods/family_connect_subscription/static/subscription_pod_template.html
@@ -35,7 +35,7 @@
         <a
             href=""
             class="pod-action list-group-item"
-            ng-repeat="action in podData.actions track by action.type"
+            ng-repeat="action in podData.actions"
             ng-class="{disabled: action.isBusy}"
             ng-click="trigger(action)">
             <span ng-if="!action.isBusy" class="text-primary">[[ action.name ]]</span>


### PR DESCRIPTION
If an identity is subscribed to multiple message sets with a switch option then all the action buttons fail to appear due to a bug in the templates. This fixes that bug.