### PR TITLE
Ensure pod can handle cursor pagination

### DIFF
--- a/casepropods/family_connect_subscription/plugin.py
+++ b/casepropods/family_connect_subscription/plugin.py
@@ -35,12 +35,12 @@ class SubscriptionPod(Pod):
             'identity': case.contact.uuid
         }
 
+        response = self.stage_based_messaging_api.get_subscriptions(params)
         try:
-            response = self.stage_based_messaging_api.get_subscriptions(params)
+            data = list(response['results'])
         except HTTPServiceError as e:
             return {"items": [{"name": "Error", "value": e.details["detail"]}]}
 
-        data = response['results']
         # Format and return data
         if len(data) < 1:
             return {"items": [{

--- a/casepropods/family_connect_subscription/plugin.py
+++ b/casepropods/family_connect_subscription/plugin.py
@@ -40,14 +40,14 @@ class SubscriptionPod(Pod):
         except HTTPServiceError as e:
             return {"items": [{"name": "Error", "value": e.details["detail"]}]}
 
+        data = response['results']
         # Format and return data
-        if response['count'] < 1:
+        if len(data) < 1:
             return {"items": [{
                 "rows": [{
                     "name": "No subscriptions", "value": ""
                 }]
             }]}
-        data = response["results"]
         content = {"items": []}
         active_sub_ids = []
         actions = []

--- a/casepropods/family_connect_subscription/tests.py
+++ b/casepropods/family_connect_subscription/tests.py
@@ -47,7 +47,6 @@ class SubscriptionPodTest(BaseCasesTest):
     def subscription_callback_no_matches(self, request):
         headers = {'Content-Type': "application/json"}
         resp = {
-            'count': 0,
             'next': None,
             'previous': None,
             'results': []
@@ -57,7 +56,6 @@ class SubscriptionPodTest(BaseCasesTest):
     def subscription_filter_callback_one_match(self, request):
         headers = {'Content-Type': "application/json"}
         resp = {
-            "count": 1,
             "next": None,
             "previous": None,
             "results": [self.subscription_data]
@@ -162,7 +160,7 @@ class SubscriptionPodTest(BaseCasesTest):
                     'old_set_name': 'test_set',
                     'subscription_id': 'sub_id'
                 }
-            },{
+            }, {
                 'type': 'full_opt_out',
                 'name': 'Full Opt-Out',
                 'confirm': True,

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(name='casepropods.family_connect_subscription',
       zip_safe=False,
       namespace_packages=['casepropods'],
       entry_points={},
-      install_requires=['seed-services-client>=0.8.0', 'pretty-cron==1.0.2'],
+      install_requires=['seed-services-client>=0.31.0', 'pretty-cron==1.0.2'],
       )


### PR DESCRIPTION
This will prevent the pod from breaking when the stage-based-messaging service starts using cursor pagination

The branch this is being pulled into is a few commits behind develop due to some work that hasn't gone live yet.

I haven't figured out how to test this independently (hence no Travis) because it relies on code in the casepro repo. I usually install a local version of casepro, then install a local version of the pod and run the tests with `./manage.py test -k ../casepropods.family_connect_subscription/casepropods/`
Here is the output:
![sub_pod_test](https://user-images.githubusercontent.com/1230707/30552263-a93c31a2-9c9d-11e7-954a-3b10af5d02ed.png)
